### PR TITLE
Specify void return type for _handleEvent method

### DIFF
--- a/lib/parallax_area.dart
+++ b/lib/parallax_area.dart
@@ -66,7 +66,7 @@ class _ParallaxAreaState extends State<ParallaxArea> {
     );
   }
 
-  _handleEvent([ScrollNotification? event]) {
+  void _handleEvent([ScrollNotification? event]) {
     if (_listeners.isNotEmpty) {
       RenderObject? renderObject = context.findRenderObject();
       _listeners.forEach((callback) {


### PR DESCRIPTION
This way it will not be inferred as dynamic