### PR TITLE
Specify void return type for method _computeParallaxOffset

### DIFF
--- a/lib/parallax_widget.dart
+++ b/lib/parallax_widget.dart
@@ -148,7 +148,7 @@ class _ParallaxWidgetState extends State<ParallaxWidget> {
   }
 
   /// Check if the current context is available and refresh the current state
-  _computeParallaxOffset(ScrollNotification? scrollNotification,
+  void _computeParallaxOffset(ScrollNotification? scrollNotification,
       RenderObject? parallaxAreaRenderObject) {
     // The widget is not rendered if the context is null, so we skip all the computations
     if (parallaxAreaRenderObject == null) {

--- a/lib/parallax_widget.dart
+++ b/lib/parallax_widget.dart
@@ -152,7 +152,7 @@ class _ParallaxWidgetState extends State<ParallaxWidget> {
       RenderObject? parallaxAreaRenderObject) {
     // The widget is not rendered if the context is null, so we skip all the computations
     if (parallaxAreaRenderObject == null) {
-      return null;
+      return;
     }
 
     final parallaxOffset = _getParallaxOffset(parallaxAreaRenderObject);


### PR DESCRIPTION
This way the return type will not be inferred as dynamic